### PR TITLE
Add RFID2 NFC write/read toggle

### DIFF
--- a/Rfid2.cpp
+++ b/Rfid2.cpp
@@ -1,0 +1,98 @@
+#include "Rfid2.h"
+
+#include <MFRC522_I2C.h>
+#include <NfcAdapter.h>
+#include <NdefMessage.h>
+#include <NdefRecord.h>
+
+// MFRC522 over I2C at address 0x28 used in the M5Stack RFID2 unit.
+static MFRC522 rfid(0x28);
+static NfcAdapter *nfc = nullptr;
+
+bool rfid2Begin(TwoWire &w) {
+  rfid.PCD_Init();          // Initialize MFRC522
+  nfc = new NfcAdapter(&rfid);
+  nfc->begin(false);
+  return true;              // Library does not expose an error code
+}
+
+bool rfid2WriteText(const String &text, String *errMsg) {
+  if (!nfc) {
+    if (errMsg)
+      *errMsg = F("not init");
+    return false;
+  }
+
+  unsigned long start = millis();
+  while (!nfc->tagPresent()) {
+    if (millis() - start > 3000) {
+      if (errMsg)
+        *errMsg = F("timeout");
+      return false;
+    }
+    delay(50);
+  }
+
+  NdefMessage message;
+  message.addTextRecord(text.c_str());
+  bool ok = nfc->write(message);
+  nfc->haltTag();
+  if (!ok) {
+    if (errMsg)
+      *errMsg = F("write error");
+  }
+  return ok;
+}
+
+bool rfid2ReadText(String *out, String *errMsg) {
+  if (!nfc) {
+    if (errMsg)
+      *errMsg = F("not init");
+    return false;
+  }
+
+  unsigned long start = millis();
+  while (!nfc->tagPresent()) {
+    if (millis() - start > 3000) {
+      if (errMsg)
+        *errMsg = F("timeout");
+      return false;
+    }
+    delay(50);
+  }
+
+  NfcTag tag = nfc->read();
+  nfc->haltTag();
+
+  if (!tag.hasNdefMessage()) {
+    if (errMsg)
+      *errMsg = F("no ndef");
+    return false;
+  }
+
+  NdefMessage msg = tag.getNdefMessage();
+  if (msg.getRecordCount() == 0) {
+    if (errMsg)
+      *errMsg = F("no record");
+    return false;
+  }
+
+  NdefRecord rec = msg.getRecord(0);
+  const byte *payload = rec.getPayload();
+  int len = rec.getPayloadLength();
+  if (len < 3) {
+    if (errMsg)
+      *errMsg = F("bad payload");
+    return false;
+  }
+  uint8_t langLen = payload[0] & 0x3F;
+  String text = "";
+  for (int i = 1 + langLen; i < len; i++) {
+    text += char(payload[i]);
+  }
+
+  if (out)
+    *out = text;
+  return true;
+}
+

--- a/Rfid2.h
+++ b/Rfid2.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <Arduino.h>
+#include <Wire.h>
+
+// Initialize the RFID2 unit. Returns true on success.
+bool rfid2Begin(TwoWire &w);
+
+// Write a text NDEF record to the tag. Returns true on success.
+// When false is returned, errMsg (if provided) contains a short reason
+// such as "timeout".
+bool rfid2WriteText(const String &text, String *errMsg = nullptr);
+
+// Read a text NDEF record from the tag. The retrieved text is stored in `out`.
+// Returns true on success.
+bool rfid2ReadText(String *out, String *errMsg = nullptr);
+


### PR DESCRIPTION
## Summary
- add minimal RFID2 wrapper for WS1850S with text NDEF read/write helpers
- integrate button edge handling to alternately write diff value or read it back via NFC
- show status messages on the OLED and log results to Serial

## Testing
- `arduino-cli core update-index` *(fails: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689caefb3cc48323a57ac61b975071e8