### PR TITLE
Use MFRC522_I2C with reset pin and simplify init

### DIFF
--- a/Rfid2.cpp
+++ b/Rfid2.cpp
@@ -3,11 +3,11 @@
 #include <MFRC522_I2C.h>
 
 // MFRC522 over I2C at address 0x28 used in the M5Stack RFID2 unit.
-static MFRC522 rfid(0x28);
+static MFRC522_I2C rfid(0x28, 26, &Wire);
 static bool initialized = false;
 
-bool rfid2Begin(TwoWire &w) {
-  w.begin();
+bool rfid2Begin() {
+  Wire.begin();
   rfid.PCD_Init();          // Initialize MFRC522
   initialized = true;
   return true;              // Library does not expose an error code
@@ -69,8 +69,8 @@ bool rfid2WriteText(const String &text, String *errMsg) {
       int idx = i + j;
       buffer[j] = (idx < totalLen) ? ndef[idx] : 0x00;
     }
-    MFRC522::StatusCode status = rfid.MIFARE_Ultralight_Write(page++, buffer, 4);
-    if (status != MFRC522::STATUS_OK) {
+    MFRC522_I2C::StatusCode status = rfid.MIFARE_Ultralight_Write(page++, buffer, 4);
+    if (status != MFRC522_I2C::STATUS_OK) {
       if (errMsg)
         *errMsg = rfid.GetStatusCodeName(status);
       rfid.PICC_HaltA();
@@ -100,8 +100,8 @@ bool rfid2ReadText(String *out, String *errMsg) {
   // Read first 4 pages starting at page 4.
   byte buffer[18];
   byte size = sizeof(buffer);
-  MFRC522::StatusCode status = rfid.MIFARE_Read(4, buffer, &size);
-  if (status != MFRC522::STATUS_OK) {
+  MFRC522_I2C::StatusCode status = rfid.MIFARE_Read(4, buffer, &size);
+  if (status != MFRC522_I2C::STATUS_OK) {
     if (errMsg)
       *errMsg = rfid.GetStatusCodeName(status);
     rfid.PICC_HaltA();
@@ -116,7 +116,7 @@ bool rfid2ReadText(String *out, String *errMsg) {
   while (readBytes < needed && readBytes < (int)sizeof(data)) {
     size = sizeof(buffer);
     status = rfid.MIFARE_Read(page, buffer, &size);
-    if (status != MFRC522::STATUS_OK) {
+    if (status != MFRC522_I2C::STATUS_OK) {
       if (errMsg)
         *errMsg = rfid.GetStatusCodeName(status);
       rfid.PICC_HaltA();

--- a/Rfid2.h
+++ b/Rfid2.h
@@ -4,7 +4,7 @@
 #include <Wire.h>
 
 // Initialize the RFID2 unit. Returns true on success.
-bool rfid2Begin(TwoWire &w);
+bool rfid2Begin();
 
 // Write a text NDEF record to the tag. Returns true on success.
 // When false is returned, errMsg (if provided) contains a short reason

--- a/dualScale.ino
+++ b/dualScale.ino
@@ -119,7 +119,7 @@ void setup() {
   Serial.begin(115200);
   pinMode(PIN_BUTTON, INPUT_PULLUP);
   Display::begin();
-  if (!rfid2Begin(Wire)) {
+  if (!rfid2Begin()) {
     Serial.println("RFID2 init failed");
   }
 


### PR DESCRIPTION
## Summary
- Replace MFRC522 instance with MFRC522_I2C including reset pin and Wire pointer
- Drop unused TwoWire parameter and initialize bus internally
- Update status code references to MFRC522_I2C and adjust setup call

## Testing
- `g++ -c Rfid2.cpp` *(fails: fatal error: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689cf26592048323aa3ef5242c18c2ef