### PR TITLE
Fix NDEF length calculations in rfid2WriteText

### DIFF
--- a/Rfid2.cpp
+++ b/Rfid2.cpp
@@ -8,9 +8,9 @@ static bool initialized = false;
 
 bool rfid2Begin(TwoWire &w) {
   w.begin();
-  rfid.PCD_Init();          // Initialize MFRC522
+  rfid.PCD_Init(); // Initialize MFRC522
   initialized = true;
-  return true;              // Library does not expose an error code
+  return true; // Library does not expose an error code
 }
 
 static bool waitForCard() {
@@ -39,28 +39,28 @@ bool rfid2WriteText(const String &text, String *errMsg) {
 
   // Build NDEF TLV for a simple text record in English.
   int textLen = text.length();
-  if (textLen > 240) {  // fits easily within Ultralight pages
+  if (textLen > 240) { // fits easily within Ultralight pages
     if (errMsg)
       *errMsg = F("too long");
     rfid.PICC_HaltA();
     return false;
   }
-  const int payloadLen = textLen + 3; // status + lang(2) + text
-  const int recordLen = payloadLen + 3; // header bytes
-  const int totalLen = recordLen + 3;  // TLV + terminator
-  byte ndef[recordLen + 3];            // will hold TLV + record
-  ndef[0] = 0x03;                      // NDEF message TLV
-  ndef[1] = recordLen;                 // length of NDEF message
-  ndef[2] = 0xD1;                      // MB/ME/SHORT/Type=0x01
-  ndef[3] = 0x01;                      // type length
-  ndef[4] = payloadLen;                // payload length
-  ndef[5] = 'T';                       // type 'T'
-  ndef[6] = 0x02;                      // UTF-8, language length=2
+  const int payloadLen = textLen + 3;   // status + lang(2) + text
+  const int recordLen = payloadLen + 4; // header bytes + type
+  const int totalLen = recordLen + 3;   // TLV + terminator
+  byte ndef[totalLen];                  // will hold TLV + record
+  ndef[0] = 0x03;                       // NDEF message TLV
+  ndef[1] = recordLen;                  // length of NDEF message
+  ndef[2] = 0xD1;                       // MB/ME/SHORT/Type=0x01
+  ndef[3] = 0x01;                       // type length
+  ndef[4] = payloadLen;                 // payload length
+  ndef[5] = 'T';                        // type 'T'
+  ndef[6] = 0x02;                       // UTF-8, language length=2
   ndef[7] = 'e';
   ndef[8] = 'n';
   for (int i = 0; i < textLen; ++i)
     ndef[9 + i] = text[i];
-  ndef[9 + textLen] = 0xFE;            // terminator TLV
+  ndef[2 + recordLen] = 0xFE; // terminator TLV
 
   byte buffer[4];
   int page = 4;
@@ -69,7 +69,8 @@ bool rfid2WriteText(const String &text, String *errMsg) {
       int idx = i + j;
       buffer[j] = (idx < totalLen) ? ndef[idx] : 0x00;
     }
-    MFRC522::StatusCode status = rfid.MIFARE_Ultralight_Write(page++, buffer, 4);
+    MFRC522::StatusCode status =
+        rfid.MIFARE_Ultralight_Write(page++, buffer, 4);
     if (status != MFRC522::STATUS_OK) {
       if (errMsg)
         *errMsg = rfid.GetStatusCodeName(status);
@@ -110,7 +111,7 @@ bool rfid2ReadText(String *out, String *errMsg) {
   }
   byte data[64];
   memcpy(data, buffer, 16);
-  int needed = 2 + buffer[1] + 1;  // TLV + message + terminator
+  int needed = 2 + buffer[1] + 1; // TLV + message + terminator
   int readBytes = 16;
   int page = 8;
   while (readBytes < needed && readBytes < (int)sizeof(data)) {
@@ -154,4 +155,3 @@ bool rfid2ReadText(String *out, String *errMsg) {
     *out = text;
   return true;
 }
-


### PR DESCRIPTION
## Summary
- correct NDEF payload, record, and total length calculations
- allocate NDEF buffer with new total length and place terminator using record length

## Testing
- `g++ -std=c++11 -c Rfid2.cpp` *(fails: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689cf2725950832388c4b0f6573d955e