### PR TITLE
Add optional serial debug logging for RFID reads/writes

### DIFF
--- a/Rfid2.cpp
+++ b/Rfid2.cpp
@@ -8,26 +8,35 @@ static bool initialized = false;
 
 
 bool rfid2Begin(TwoWire &w) {
+  RFID2_DEBUG_PRINT("rfid2Begin: start\n");
   w.begin();
   rfid.PCD_Init(); // Initialize MFRC522
+  RFID2_DEBUG_PRINT("rfid2Begin: initialized\n");
 
   initialized = true;
   return true; // Library does not expose an error code
 }
 
 static bool waitForCard() {
+  RFID2_DEBUG_PRINT("waitForCard: waiting for tag\n");
   unsigned long start = millis();
   while (true) {
-    if (rfid.PICC_IsNewCardPresent() && rfid.PICC_ReadCardSerial())
+    if (rfid.PICC_IsNewCardPresent() && rfid.PICC_ReadCardSerial()) {
+      RFID2_DEBUG_PRINT("waitForCard: tag detected\n");
       return true;
-    if (millis() - start > 3000)
+    }
+    if (millis() - start > 3000) {
+      RFID2_DEBUG_PRINT("waitForCard: timeout\n");
       return false;
+    }
     delay(50);
   }
 }
 
 bool rfid2WriteText(const String &text, String *errMsg) {
+  RFID2_DEBUG_PRINT("rfid2WriteText: '%s'\n", text.c_str());
   if (!initialized) {
+    RFID2_DEBUG_PRINT("rfid2WriteText: not initialized\n");
     if (errMsg)
       *errMsg = F("not init");
     return false;
@@ -38,10 +47,12 @@ bool rfid2WriteText(const String &text, String *errMsg) {
       *errMsg = F("timeout");
     return false;
   }
+  RFID2_DEBUG_PRINT("rfid2WriteText: card ready\n");
 
   // Build NDEF TLV for a simple text record in English.
   int textLen = text.length();
   if (textLen > 240) { // fits easily within Ultralight pages
+    RFID2_DEBUG_PRINT("rfid2WriteText: text too long (%d)\n", textLen);
     if (errMsg)
       *errMsg = F("too long");
     rfid.PICC_HaltA();
@@ -50,6 +61,7 @@ bool rfid2WriteText(const String &text, String *errMsg) {
   const int payloadLen = textLen + 3;   // status + lang(2) + text
   const int recordLen = payloadLen + 4; // header bytes + type
   const int totalLen = recordLen + 3;   // TLV + terminator
+  RFID2_DEBUG_PRINT("rfid2WriteText: payload=%d record=%d total=%d\n", payloadLen, recordLen, totalLen);
   byte ndef[totalLen];                  // will hold TLV + record
   ndef[0] = 0x03;                       // NDEF message TLV
   ndef[1] = recordLen;                  // length of NDEF message
@@ -72,23 +84,30 @@ bool rfid2WriteText(const String &text, String *errMsg) {
       buffer[j] = (idx < totalLen) ? ndef[idx] : 0x00;
     }
 
-    MFRC522_I2C::StatusCode status = rfid.MIFARE_Ultralight_Write(page++, buffer, 4);
+    RFID2_DEBUG_PRINT("Writing page %d: %02X %02X %02X %02X\n", page, buffer[0], buffer[1], buffer[2], buffer[3]);
+    MFRC522_I2C::StatusCode status = rfid.MIFARE_Ultralight_Write(page, buffer, 4);
     if (status != MFRC522_I2C::STATUS_OK) {
+      RFID2_DEBUG_PRINT("Write failed at page %d: %s\n", page, rfid.GetStatusCodeName(status));
       if (errMsg)
         *errMsg = rfid.GetStatusCodeName(status);
       rfid.PICC_HaltA();
       rfid.PCD_StopCrypto1();
       return false;
     }
+    RFID2_DEBUG_PRINT("Page %d written\n", page);
+    page++;
   }
 
   rfid.PICC_HaltA();
   rfid.PCD_StopCrypto1();
+  RFID2_DEBUG_PRINT("rfid2WriteText: complete\n");
   return true;
 }
 
 bool rfid2ReadText(String *out, String *errMsg) {
+  RFID2_DEBUG_PRINT("rfid2ReadText: start\n");
   if (!initialized) {
+    RFID2_DEBUG_PRINT("rfid2ReadText: not initialized\n");
     if (errMsg)
       *errMsg = F("not init");
     return false;
@@ -99,12 +118,15 @@ bool rfid2ReadText(String *out, String *errMsg) {
       *errMsg = F("timeout");
     return false;
   }
+  RFID2_DEBUG_PRINT("rfid2ReadText: card ready\n");
 
   // Read first 4 pages starting at page 4.
   byte buffer[18];
   byte size = sizeof(buffer);
+  RFID2_DEBUG_PRINT("Reading page 4\n");
   MFRC522_I2C::StatusCode status = rfid.MIFARE_Read(4, buffer, &size);
   if (status != MFRC522_I2C::STATUS_OK) {
+    RFID2_DEBUG_PRINT("Read failed at page 4: %s\n", rfid.GetStatusCodeName(status));
     if (errMsg)
       *errMsg = rfid.GetStatusCodeName(status);
     rfid.PICC_HaltA();
@@ -118,8 +140,10 @@ bool rfid2ReadText(String *out, String *errMsg) {
   int page = 8;
   while (readBytes < needed && readBytes < (int)sizeof(data)) {
     size = sizeof(buffer);
+    RFID2_DEBUG_PRINT("Reading page %d\n", page);
     status = rfid.MIFARE_Read(page, buffer, &size);
     if (status != MFRC522_I2C::STATUS_OK) {
+      RFID2_DEBUG_PRINT("Read failed at page %d: %s\n", page, rfid.GetStatusCodeName(status));
       if (errMsg)
         *errMsg = rfid.GetStatusCodeName(status);
       rfid.PICC_HaltA();
@@ -135,6 +159,7 @@ bool rfid2ReadText(String *out, String *errMsg) {
   rfid.PCD_StopCrypto1();
 
   if (data[0] != 0x03 || data[2] != 0xD1 || data[3] != 0x01 || data[5] != 'T') {
+    RFID2_DEBUG_PRINT("rfid2ReadText: no NDEF header\n");
     if (errMsg)
       *errMsg = F("no ndef");
     return false;
@@ -143,6 +168,7 @@ bool rfid2ReadText(String *out, String *errMsg) {
   int payloadLen = data[4];
   int langLen = data[6] & 0x3F;
   if (payloadLen < 1 + langLen) {
+    RFID2_DEBUG_PRINT("rfid2ReadText: bad payload len=%d lang=%d\n", payloadLen, langLen);
     if (errMsg)
       *errMsg = F("bad payload");
     return false;
@@ -153,6 +179,7 @@ bool rfid2ReadText(String *out, String *errMsg) {
   for (int i = 0; i < textLen; ++i)
     text += char(data[textStart + i]);
 
+  RFID2_DEBUG_PRINT("rfid2ReadText: decoded '%s'\n", text.c_str());
   if (out)
     *out = text;
   return true;

--- a/Rfid2.h
+++ b/Rfid2.h
@@ -3,8 +3,15 @@
 #include <Arduino.h>
 #include <Wire.h>
 
+// Enable verbose debug logging when RFID2_DEBUG is defined.
+#ifdef RFID2_DEBUG
+#define RFID2_DEBUG_PRINT(...) Serial.printf(__VA_ARGS__)
+#else
+#define RFID2_DEBUG_PRINT(...)
+#endif
+
 // Initialize the RFID2 unit. Returns true on success.
-bool rfid2Begin();
+bool rfid2Begin(TwoWire &w = Wire);
 
 // Write a text NDEF record to the tag. Returns true on success.
 // When false is returned, errMsg (if provided) contains a short reason


### PR DESCRIPTION
## Summary
- add `RFID2_DEBUG` toggle and macros for serial debug prints
- instrument RFID init, card wait, write, and read paths with detailed debug messages
- allow `rfid2Begin` to take an optional `TwoWire` reference (defaults to `Wire`)

## Testing
- `arduino-cli compile --fqbn esp32:esp32:esp32 .` *(failed: Error downloading index 'https://downloads.arduino.cc/libraries/library_index.tar.bz2': connect: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d08624e18832383a779180f2b2c50