### PR TITLE
Fix misinterpreted RFID write status

### DIFF
--- a/Rfid2.cpp
+++ b/Rfid2.cpp
@@ -1,5 +1,6 @@
 #include "Rfid2.h"
 
+#include <MFRC522.h>     // Base MFRC522 library for StatusCode definitions
 #include <MFRC522_I2C.h>
 
 // MFRC522 over I2C at address 0x28 used in the M5Stack RFID2 unit.
@@ -72,8 +73,8 @@ bool rfid2WriteText(const String &text, String *errMsg) {
       buffer[j] = (idx < totalLen) ? ndef[idx] : 0x00;
     }
 
-    MFRC522_I2C::StatusCode status = rfid.MIFARE_Ultralight_Write(page++, buffer, 4);
-    if (status != MFRC522_I2C::STATUS_OK) {
+    MFRC522::StatusCode status = rfid.MIFARE_Ultralight_Write(page++, buffer, 4);
+    if (status != MFRC522::STATUS_OK) {
       if (errMsg)
         *errMsg = rfid.GetStatusCodeName(status);
       rfid.PICC_HaltA();
@@ -103,8 +104,8 @@ bool rfid2ReadText(String *out, String *errMsg) {
   // Read first 4 pages starting at page 4.
   byte buffer[18];
   byte size = sizeof(buffer);
-  MFRC522_I2C::StatusCode status = rfid.MIFARE_Read(4, buffer, &size);
-  if (status != MFRC522_I2C::STATUS_OK) {
+  MFRC522::StatusCode status = rfid.MIFARE_Read(4, buffer, &size);
+  if (status != MFRC522::STATUS_OK) {
     if (errMsg)
       *errMsg = rfid.GetStatusCodeName(status);
     rfid.PICC_HaltA();
@@ -119,7 +120,7 @@ bool rfid2ReadText(String *out, String *errMsg) {
   while (readBytes < needed && readBytes < (int)sizeof(data)) {
     size = sizeof(buffer);
     status = rfid.MIFARE_Read(page, buffer, &size);
-    if (status != MFRC522_I2C::STATUS_OK) {
+    if (status != MFRC522::STATUS_OK) {
       if (errMsg)
         *errMsg = rfid.GetStatusCodeName(status);
       rfid.PICC_HaltA();

--- a/Rfid2.h
+++ b/Rfid2.h
@@ -3,8 +3,10 @@
 #include <Arduino.h>
 #include <Wire.h>
 
-// Initialize the RFID2 unit. Returns true on success.
-bool rfid2Begin();
+// Initialize the RFID2 unit. Returns true on success.  Optionally allow the
+// caller to specify the I2C interface, defaulting to the global `Wire`
+// instance so existing call sites can simply invoke `rfid2Begin()`.
+bool rfid2Begin(TwoWire &w = Wire);
 
 // Write a text NDEF record to the tag. Returns true on success.
 // When false is returned, errMsg (if provided) contains a short reason


### PR DESCRIPTION
## Summary
- Allow selecting I2C bus when starting RFID and default to global Wire instance
- Compare RFID status against base MFRC522 codes so write/read success is detected correctly

## Testing
- `g++ -c Rfid2.cpp` *(fails: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689cfe22574883239616867d2d2e5718